### PR TITLE
modify: NotableDrop Image unoptimized

### DIFF
--- a/apps/client/src/components/main/molecule/NotableDrop.tsx
+++ b/apps/client/src/components/main/molecule/NotableDrop.tsx
@@ -19,6 +19,7 @@ function NotableDrop({ item }: NotableDropProps) {
 						src={item.thumbnailUrl || ""}
 						alt={item.productName}
 						fill
+						unoptimized
 						sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
 						className="h-full w-full object-cover"
 					/>


### PR DESCRIPTION
This pull request includes a small change to the `NotableDrop` component in the `NotableDrop.tsx` file. The change adds the `unoptimized` attribute to the image element to address potential performance issues with image loading.

* [`apps/client/src/components/main/molecule/NotableDrop.tsx`](diffhunk://#diff-ce9efebb93f763deda581bfb1694d1612fcce8fc6079a8e9145fd1709acab313R22): Added the `unoptimized` attribute to the image element in the `NotableDrop` component to improve performance.